### PR TITLE
Adds multi-stat potions

### DIFF
--- a/scripts/data/dataPotions.js
+++ b/scripts/data/dataPotions.js
@@ -7,6 +7,15 @@ define([''], function () {
   var potions = [//* Put tests here
   // [{effect:'customStat',   params:[{stats:[['lch', -4], ['hpr', 2]]}], icon:153, tooltip:'-4 LEECH\n+2 REGEN'}, {effect:'customStat',   params:[{stats:[['lch', 4], ['hpr', -2]]}], icon:154, tooltip:'-2 REGEN\n+4 LEECH'}, {effect:'experience',    params:[2000], icon:145, tooltip:'+1200 EXP'}],
   //* Potions
+  // Will - Test multiple stat potions
+  [{
+    effect: 'multipleStat',
+    params: [{
+      positive: ['dmg', 'arm'],
+      negative: ['mhp']
+    }]
+  }]
+  // Will - End test multiple stat potions
   [{
     effect: 'randomStat',
     params: []

--- a/scripts/data/dataPotions.js
+++ b/scripts/data/dataPotions.js
@@ -14,7 +14,7 @@ define([''], function () {
       positive: ['dmg', 'arm'],
       negative: ['mhp']
     }]
-  }]
+  }],
   // Will - End test multiple stat potions
   [{
     effect: 'randomStat',

--- a/scripts/itemUsable.js
+++ b/scripts/itemUsable.js
@@ -64,6 +64,36 @@ define(['game', 'stats', 'dataItems'], function (game, Stats, DataItems) {
         this.stats.addFromData(statData);
       }
     }, {
+      key: "multipleStatGenerate",
+      value: function multipleStatGenerate(data) {
+        const statNames = ['dmg', 'mhp', 'arm'];
+        const tooltipNames = ['ATK', 'HP', 'DEF']
+
+        const stats = [];
+        const tooltip = [];
+
+        for (const stat of data.positive) {
+          const type = names.indexOf(stat);
+          const base = DataItems[type].stats[0][1];
+          const value = this.getValue(base);
+          stats.push([stat, value]);
+          tooltip.push(`+${value} ${tooltipName[type]}`);
+        }
+
+        for (const stat of data.negative) {
+          const type = names.indexOf(stat);
+          const base = DataItems[type].stats[0][1];
+          const value = -this.getValue(base);
+          stats.push([stat, value]);
+          tooltip.push(`-${value} ${tooltipName[type]}`);
+        }
+
+        const statData = {
+          stats: stats,
+          tooltip: tooltip.join(", ")
+        }
+      }
+    }, {
       key: "getValue",
       value: function getValue(base) {
         var formula = function formula(level) {
@@ -93,6 +123,11 @@ define(['game', 'stats', 'dataItems'], function (game, Stats, DataItems) {
     }, {
       key: "randomStatUse",
       value: function randomStatUse() {
+        this.applyStats();
+      }
+    }, {
+      key: "multipleStatUse",
+      value: function multipleStatUse() {
         this.applyStats();
       }
     }, {

--- a/scripts/itemUsable.js
+++ b/scripts/itemUsable.js
@@ -67,31 +67,32 @@ define(['game', 'stats', 'dataItems'], function (game, Stats, DataItems) {
       key: "multipleStatGenerate",
       value: function multipleStatGenerate(data) {
         const statNames = ['dmg', 'mhp', 'arm'];
-        const tooltipNames = ['ATK', 'HP', 'DEF']
+        const tooltipNames = ['ATK', 'HP', 'DEF'];
 
         const stats = [];
         const tooltip = [];
 
         for (const stat of data.positive) {
-          const type = names.indexOf(stat);
+          const type = statNames.indexOf(stat);
           const base = DataItems[type].stats[0][1];
           const value = this.getValue(base);
           stats.push([stat, value]);
-          tooltip.push(`+${value} ${tooltipName[type]}`);
+          tooltip.push(`+${value} ${tooltipNames[type]}`);
         }
 
         for (const stat of data.negative) {
-          const type = names.indexOf(stat);
+          const type = statNames.indexOf(stat);
           const base = DataItems[type].stats[0][1];
           const value = -this.getValue(base);
           stats.push([stat, value]);
-          tooltip.push(`-${value} ${tooltipName[type]}`);
+          tooltip.push(`-${value} ${tooltipNames[type]}`);
         }
 
         const statData = {
           stats: stats,
           tooltip: tooltip.join(", ")
         }
+        this.stats.addFromData(statData);
       }
     }, {
       key: "getValue",


### PR DESCRIPTION
This PR adds the `multipleStat` potion effect. This potion acts like the `randomStat` potion, but can be configured to add or remove from multiple stats. With the potion data here, the first potion will randomly add defense and attack, and take away from health:
```javascript
{
  effect: 'multipleStat',
  params: [{
    positive: ['dmg', 'arm'],
    negative: ['mhp']
  }]
}
```

![image](https://github.com/user-attachments/assets/cc3ef7a4-2bac-46a9-808b-a007507dcd68)
![image](https://github.com/user-attachments/assets/7844b4cb-1c52-4149-aa57-199b4f9922b9)
